### PR TITLE
fix: 이메일 유효성 검사, 닉네임 중복 검사 에러 고침

### DIFF
--- a/src/components/pageComponents/for-auth/EmailInput.jsx
+++ b/src/components/pageComponents/for-auth/EmailInput.jsx
@@ -50,7 +50,10 @@ const EmailInput = ({ register, setValue, errors, watch }) => {
           {...register("emailPrefix", {
             required: "이메일을 입력해주세요.",
             pattern: {
-              value: /^[A-Z0-9._%+-]+$/i, // prefix만 검사
+              value:
+                emailDomain === "custom"
+                  ? /^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}$/i // 전체 이메일 형식 검증
+                  : /^[A-Z0-9._%+-]+$/i, // prefix만 검증
             },
           })}
           className="w-full p-2 h-10 border rounded focus:outline-none focus:ring"
@@ -70,7 +73,22 @@ const EmailInput = ({ register, setValue, errors, watch }) => {
         </select>
       </div>
       {/* 이메일 유효성 검사 메시지 */}
-      {emailPrefix && !/^[A-Z0-9._%+-]+$/i.test(emailPrefix) ? ( // prefix 실시간 검증
+      {emailDomain === "custom" ? (
+        // emailDomain이 "custom"일 때 전체 이메일 형식 검증
+        emailPrefix &&
+        !/^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}$/i.test(emailPrefix) ? (
+          <p className="text-red-500 text-sm mt-1">
+            유효한 이메일 형식이 아닙니다.
+          </p>
+        ) : (
+          errors.emailPrefix && (
+            <p className="text-red-500 text-sm mt-1">
+              {errors.emailPrefix.message}
+            </p>
+          )
+        )
+      ) : // emailDomain이 "custom"이 아닐 때 prefix 검증
+      emailPrefix && !/^[A-Z0-9._%+-]+$/i.test(emailPrefix) ? (
         <p className="text-red-500 text-sm mt-1">
           유효한 이메일 형식이 아닙니다.
         </p>

--- a/src/components/pageComponents/for-auth/NicknameInput.jsx
+++ b/src/components/pageComponents/for-auth/NicknameInput.jsx
@@ -27,6 +27,7 @@ const NicknameInput = ({
   clearErrors,
   setValue,
   watch,
+  trigger
 }) => {
   const [checking, setChecking] = useState(false);
   const [nicknameAvailable, setNicknameAvailable] = useState(false);
@@ -34,10 +35,16 @@ const NicknameInput = ({
   const nickname = watch("nickname"); // 닉네임 값 실시간 감지
 
   useEffect(() => {
-    // 닉네임 변경 시 상태 초기화 및 React Hook Form 상태 업데이트
+    // 닉네임 변경 시 상태 초기화
     setNicknameAvailable(false);
-    clearErrors("nickname"); // 기존 에러 초기화
-  }, [nickname, clearErrors]);
+    clearErrors("nickname");
+    setValue("nicknameAvailable", false); // 닉네임 사용 가능 상태 초기화
+  }, [nickname, clearErrors, setValue]);
+
+    useEffect(() => {
+      // 닉네임 사용 가능 상태가 변경되면 유효성 검사 트리거
+      trigger("nickname");
+    }, [nicknameAvailable, trigger]);
 
   const checkNickname = async (nickname) => {
     if (!nickname) return;
@@ -64,7 +71,7 @@ const NicknameInput = ({
         clearErrors("nickname");
         setNicknameAvailable(true);
         // React Hook Form에 닉네임 사용 가능 상태 업데이트
-        setValue("nicknameAvailable", true, { shouldValidate: true });
+        setValue("nicknameAvailable", true);
       }
     } catch (err) {
       console.error("Error checking nickname:", err.message);

--- a/src/pages/auth/SignUp.jsx
+++ b/src/pages/auth/SignUp.jsx
@@ -23,7 +23,7 @@ const SignUp = () => {
     setValue,
     setError,
     clearErrors,
-
+    trigger,
     formState: { errors, isValid },
   } = useForm({
     mode: "onChange", // 입력값이 변경될 때마다 유효성 검사
@@ -126,6 +126,7 @@ const SignUp = () => {
             errors={errors}
             watch={watch}
             setValue={setValue}
+            trigger={trigger}
           />
           <button
             type="submit"


### PR DESCRIPTION
1. 닉네임 중복 유효성 검사가 useform내부에서 제대로 진행이 안되서 다른 조건 충족 시에도 닉네임 중복 확인 후 버튼 enable이 안되는 에러가 있었습니다.---> trigger 추가해서 다른 조건 충족시 닉네임 중복 확인 후에 바로 버튼 enable 되도록 수정 했습니다.

2. 이메일 직접 입력 시랑 도메인 선택 시 다른 조건으로 유효성 검사를 했어야했는데 그 부분을 뺴먹어서 추가했습니다.

(+ 혹시나 시간이 여유로운신 분들 sign up, login 유효성 검사 한번만 해주시고, 오류나 개선되었으면 하는 부분 있으면 꼭 말해주세용!! 😉)